### PR TITLE
Removed check for Python 3.4 compatibility as it breaks in Python 3.7

### DIFF
--- a/pyemby/server.py
+++ b/pyemby/server.py
@@ -22,12 +22,7 @@ from pyemby.helpers import deprecated_name
 
 _LOGGER = logging.getLogger(__name__)
 
-# pylint: disable=invalid-name,no-member
-try:
-    ensure_future = asyncio.ensure_future
-except AttributeError:
-    # Python 3.4.3 and earlier has this as async
-    ensure_future = asyncio.async
+ensure_future = asyncio.ensure_future
 
 """
 Some general project notes that don't fit anywhere else:


### PR DESCRIPTION
async is a reserved word in Python 3.7, causing pyEmby fail with this
error:

File "/usr/lib/python3.7/site-packages/pyemby/__init__.py", line 10,
in <module>
    from .server import EmbyServer
  File "/usr/lib/python3.7/site-packages/pyemby/server.py", line 30
    ensure_future = asyncio.async