### PR TITLE
Clean server payloads to remove None values

### DIFF
--- a/pyemby/helpers.py
+++ b/pyemby/helpers.py
@@ -5,6 +5,7 @@ Function helpers.
 Copyright (c) 2017-2019 John Mihalic <https://github.com/mezz64>
 Licensed under the MIT license.
 """
+import collections.abc
 
 
 def deprecated_name(name):
@@ -20,3 +21,44 @@ def deprecated_name(name):
                 return func(self)
         return func_wrapper
     return decorator
+
+
+def clean_none_dict_values(obj):
+    """
+    Recursively remove keys with a value of None
+    """
+    if not isinstance(obj, collections.abc.Iterable) or isinstance(obj, str):
+        return obj
+
+    queue = [obj]
+
+    while queue:
+        item = queue.pop()
+
+        if isinstance(item, collections.abc.Mapping):
+            mutable = isinstance(item, collections.abc.MutableMapping)
+            remove = []
+
+            for key, value in item.items():
+                if value is None and mutable:
+                    remove.append(key)
+
+                elif isinstance(value, str):
+                    continue
+
+                elif isinstance(value, collections.abc.Iterable):
+                    queue.append(value)
+
+            if mutable:
+                # Remove keys with None value
+                for key in remove:
+                    item.pop(key)
+
+        elif isinstance(item, collections.abc.Iterable):
+            for value in item:
+                if value is None or isinstance(value, str):
+                    continue
+                elif isinstance(value, collections.abc.Iterable):
+                    queue.append(value)
+
+    return obj

--- a/pyemby/server.py
+++ b/pyemby/server.py
@@ -18,7 +18,7 @@ from pyemby.device import EmbyDevice
 from pyemby.constants import (
     __version__, DEFAULT_TIMEOUT, DEFAULT_HEADERS, API_URL, SOCKET_URL,
     STATE_PAUSED, STATE_PLAYING, STATE_IDLE)
-from pyemby.helpers import deprecated_name
+from pyemby.helpers import deprecated_name, clean_none_dict_values
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -203,7 +203,7 @@ class EmbyServer(object):
         else:
             self._registered = True
             _LOGGER.info('Emby client registered!, Id: %s', self.unique_id)
-            self._sessions = reg
+            self._sessions = clean_none_dict_values(reg)
 
             # Build initial device list.
             self.update_device_list(self._sessions)
@@ -314,7 +314,7 @@ class EmbyServer(object):
 
         _LOGGER.debug('New websocket message recieved of type: %s', msgtype)
         if msgtype == 'Sessions':
-            self._sessions = msgdata
+            self._sessions = clean_none_dict_values(msgdata)
             # Check for new devices and update as needed.
             self.update_device_list(self._sessions)
         """


### PR DESCRIPTION
Adds a new helper function that parses the json payloads from the server to remove keys that have a value of `None`.  Mostly only relevant when connecting to a Jellyfin server currently, but fixes #7 and by extension should fix https://github.com/home-assistant/core/issues/38501.

I only spun up homeassistant to look into this and haven't been able to do a ton of testing just by nature of being unfamiliar with it, but I'm no longer getting the error logs on startup that I was initially so I think it's fixed.