### PR TITLE
Handle Ping message

### DIFF
--- a/pyemby/server.py
+++ b/pyemby/server.py
@@ -294,7 +294,7 @@ class EmbyServer(object):
 
             except (aiohttp.ClientError, asyncio.TimeoutError,
                     aiohttp.WSServerHandshakeError,
-                    ConnectionRefusedError, OSError, ValueError) as err:
+                    ConnectionRefusedError, OSError, KeyError, ValueError) as err:
                 if not self._shutdown:
                     fail_count += 1
                     _LOGGER.debug('Websocket unintentionally closed.'

--- a/pyemby/server.py
+++ b/pyemby/server.py
@@ -308,8 +308,8 @@ class EmbyServer(object):
     def process_msg(self, msg):
         """Process messages from the event stream."""
         jmsg = json.loads(msg)
-        msgtype = jmsg['MessageType']
-        msgdata = jmsg['Data']
+        msgtype = jmsg.get('MessageType', 'unknown')
+        msgdata = jmsg.get('Data', None)
 
         _LOGGER.debug('New websocket message recieved of type: %s', msgtype)
         if msgtype == 'Sessions':
@@ -319,6 +319,7 @@ class EmbyServer(object):
         """
         May process other message types in the future.
         Other known types are:
+        - Ping (no data)
         - PlaybackStarted
         - PlaybackStopped
         - SessionEnded


### PR DESCRIPTION
This PR adds support for the no-op Ping message which seems to break connections with Emby 4.8.

The Ping message doesn't have a 'Data'field, which results in the below exception:
```
{"MessageType":"Ping"}
```
```
>>> emby.start()
Task exception was never retrieved
future: <Task finished name='Task-4' coro=<EmbyServer.socket_connection() done, defined at /usr/local/lib/python3.11/site-packages/pyemby/server.py:255> exception=KeyError('Data')>
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/pyemby/server.py", line 287, in socket_connection
    self.process_msg(msg.data)
  File "/usr/local/lib/python3.11/site-packages/pyemby/server.py", line 315, in process_msg
    msgdata = jmsg['Data']
              ~~~~^^^^^^^^
```