### PR TITLE
Enable websocket heartbeats for improved connection stability

### DIFF
--- a/pyemby/constants.py
+++ b/pyemby/constants.py
@@ -2,12 +2,12 @@
 pyemby.constants
 ~~~~~~~~~~~~~~~~~~~~
 Constants list
-Copyright (c) 2017-2023 John Mihalic <https://github.com/mezz64>
+Copyright (c) 2017-2024 John Mihalic <https://github.com/mezz64>
 Licensed under the MIT license.
 """
 
 MAJOR_VERSION = 1
-MINOR_VERSION = 9
+MINOR_VERSION = 10
 __version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 
 DEFAULT_TIMEOUT = 10

--- a/pyemby/server.py
+++ b/pyemby/server.py
@@ -266,7 +266,7 @@ class EmbyServer(object):
             _LOGGER.debug('Attempting Socket Connection.')
             try:
                 with async_timeout.timeout(DEFAULT_TIMEOUT):
-                    self.wsck = await self._api_session.ws_connect(url)
+                    self.wsck = await self._api_session.ws_connect(url, heartbeat=300)
 
                 # Enable sever session updates:
                 try:

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,12 @@ from distutils.core import setup
 setup(
     name='pyEmby',
     packages=['pyemby'],
-    version='1.9',
+    version='1.10',
     description='Provides a python interface to interact with a Emby media server.',
     author='John Mihalic',
     author_email='mezz64@users.noreply.github.com',
     url='https://github.com/mezz64/pyemby',
-    download_url = 'https://github.com/mezz64/pyemby/tarball/1.9',
+    download_url = 'https://github.com/mezz64/pyemby/tarball/1.10',
     keywords= ['emby', 'media sever', 'api wrapper'],
     classifiers = [],
     )


### PR DESCRIPTION
I noticed that with newer versions of emby, when idle for longer periods of time something stops working with the websocket.

I tried a few different things, but this seems to be effective at preventing the issue, and seems very low touch. 